### PR TITLE
Update filament/filament dependency to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": "^8.2",
-    "filament/filament": "^4.0"
+    "filament/filament": "^5.0"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,


### PR DESCRIPTION
This pull request updates the `filament/filament` package dependency in the `composer.json` file from version 4.x to 5.x, ensuring the project uses the latest major release of Filament. This may introduce breaking changes or new features from Filament 5.

- Dependency upgrade:
  * Updated the `filament/filament` requirement in `composer.json` from `^4.0` to `^5.0` to use the latest major version.